### PR TITLE
Update `Runner.on`

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -14,12 +14,12 @@ Runner
 .. autoclass:: Runner
    :members:
 
-.. _Handlers:
+.. _Callbacks:
 
-Handlers
---------
+Callbacks
+---------
 
-.. currentmodule:: rnnr.handlers
+.. currentmodule:: rnnr.callbacks
 
 .. autoclass:: EarlyStopper
    :members:

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -36,13 +36,13 @@ To run the trainer, simply invoke the `~Runner.run` method.
 
    trainer.run(batch_fn, batches, max_epoch=5)
 
-Handling events
----------------
+Listening for events
+--------------------
 
 The above example is the minimum requirement to use a `Runner`. However, usually we want to
 have some more control of what we do on the start of each epoch, end of each batch, and so on.
 Heavily inspired by Ignite_, **rnnr** also uses an event system: during a run, the runner
-emits events and we can provide handler for them.
+emits events and we can provide callbacks for them.
 
 .. code-block:: python
 
@@ -56,9 +56,9 @@ emits events and we can provide handler for them.
    def print_epoch(state):
        print('Epoch', state['epoch'], 'started')
 
-Now, when ``trainer`` is run, these handlers will be invoked at the start of the run and the
-start of each epoch respectively. The `~Runner.on` method can also be used not as a decorator
-by passing a handler as its second argument.
+Now, when ``trainer`` is run, these callbacks will be invoked at the start of the run and the
+start of each epoch respectively. The `~Runner.on` method can also be used *not* as a decorator
+by passing a callback as its second argument.
 
 .. code-block:: python
 
@@ -68,14 +68,14 @@ by passing a handler as its second argument.
    trainer.on(Event.EPOCH_FINISHED, print_epoch_finished)
 
 See `Runner` for more details. For more information on what events are available, see `Event`
-instead. Please check :ref:`Handlers` for some useful handlers.
+instead. Please check :ref:`Callbacks` for some useful callbacks.
 
-Handlers that work together: an attachment
-------------------------------------------
+Callbacks that work together: an attachment
+-------------------------------------------
 
-An attachment is a collection of handlers that work together to provide some functionality.
-For example, to compute a mean over batch statistics, we need to append handlers to many
-events, and these handlers work together to obtain the mean value. In **rnnr**, this concept
+An attachment is a collection of callbacks that work together to provide some functionality.
+For example, to compute a mean over batch statistics, we need to append callbacks to many
+events, and these callbacks work together to obtain the mean value. In **rnnr**, this concept
 is realized by the `~attachments.Attachment` abstract base class. We can create our own
 attachments, but some useful attachments are provided. See :ref:`Attachments` for more.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -57,15 +57,15 @@ emits events and we can provide handler for them.
        print('Epoch', state['epoch'], 'started')
 
 Now, when ``trainer`` is run, these handlers will be invoked at the start of the run and the
-start of each epoch respectively. It is also possible to provide a handler using
-`~Runner.append_handler` method.
+start of each epoch respectively. The `~Runner.on` method can also be used not as a decorator
+by passing a handler as its second argument.
 
 .. code-block:: python
 
    def print_epoch_finished(state):
        print('Epoch', state['epoch'], 'of', state['max_epoch'], 'finished')
 
-   trainer.append_handler(Event.EPOCH_FINISHED, print_epoch_finished)
+   trainer.on(Event.EPOCH_FINISHED, print_epoch_finished)
 
 See `Runner` for more details. For more information on what events are available, see `Event`
 instead. Please check :ref:`Handlers` for some useful handlers.

--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -23,6 +23,7 @@ from .runner import Runner
 
 class Attachment(abc.ABC):
     """An abstract base class for an attachment."""
+
     @abc.abstractmethod
     def attach_on(self, runner: Runner) -> None:
         """Attach to the given runner.
@@ -58,6 +59,7 @@ class ProgressBar(Attachment):
 
     .. _tqdm: https://github.com/tqdm/tqdm
     """
+
     def __init__(
             self,
             size_key: str = 'n_items',
@@ -76,9 +78,9 @@ class ProgressBar(Attachment):
         self._pbar: tqdm
 
     def attach_on(self, runner: Runner) -> None:
-        runner.append_handler(Event.EPOCH_STARTED, self._create)
-        runner.append_handler(Event.BATCH_FINISHED, self._update)
-        runner.append_handler(Event.EPOCH_FINISHED, self._close)
+        runner.on(Event.EPOCH_STARTED, self._create)
+        runner.on(Event.BATCH_FINISHED, self._update)
+        runner.on(Event.EPOCH_FINISHED, self._close)
 
     def _create(self, state: dict) -> None:
         self._pbar = self._tqdm_cls(state['batches'], **self._kwargs)
@@ -118,6 +120,7 @@ class LambdaReducer(Attachment):
             return their reduction result.
         value_key: Get the value of a batch from ``state[value_key]``.
     """
+
     def __init__(
             self,
             name: str,
@@ -129,9 +132,9 @@ class LambdaReducer(Attachment):
         self._value_key = value_key
 
     def attach_on(self, runner: Runner) -> None:
-        runner.append_handler(Event.EPOCH_STARTED, self._reset)
-        runner.append_handler(Event.BATCH_FINISHED, self._update)
-        runner.append_handler(Event.EPOCH_FINISHED, self._compute)
+        runner.on(Event.EPOCH_STARTED, self._reset)
+        runner.on(Event.BATCH_FINISHED, self._update)
+        runner.on(Event.EPOCH_FINISHED, self._compute)
 
     def _reset(self, state: dict) -> None:
         self._result = None
@@ -173,6 +176,7 @@ class MeanReducer(LambdaReducer):
             the state has no such key, the size defaults to 1. The sum of all these
             batch sizes is the divisor when computing the mean.
     """
+
     def __init__(
             self,
             name: str = 'mean',

--- a/rnnr/callbacks.py
+++ b/rnnr/callbacks.py
@@ -22,7 +22,7 @@ import warnings
 logger = logging.getLogger(__name__)
 
 
-class ImprovementHandlerMixin:
+class ImprovementCallbackMixin:
     def __init__(self, mode: str = 'min', *, eps: float = 1e-4) -> None:
         if mode not in ('min', 'max'):  # pragma: no cover
             warnings.warn("mode {mode!r} is unknown; will be interpreted as 'max'")
@@ -46,11 +46,11 @@ class ImprovementHandlerMixin:
         return value > self.best_value
 
 
-class EarlyStopper(ImprovementHandlerMixin):
-    """A handler for early stopping.
+class EarlyStopper(ImprovementCallbackMixin):
+    """A callback for early stopping.
 
-    This handler keeps track the number of times some value does not improve. If this
-    number is greater than the given patience, this handler stops the given runner.
+    This callback keeps track the number of times some value does not improve. If this
+    number is greater than the given patience, this callback stops the given runner.
 
     Example:
 
@@ -60,7 +60,7 @@ class EarlyStopper(ImprovementHandlerMixin):
         >>>
         >>> from rnnr import Event, Runner
         >>> from rnnr.attachments import MeanReducer
-        >>> from rnnr.handlers import EarlyStopper
+        >>> from rnnr.callbacks import EarlyStopper
         >>>
         >>> trainer = Runner()
         >>> @trainer.on(Event.EPOCH_STARTED)
@@ -117,8 +117,8 @@ class EarlyStopper(ImprovementHandlerMixin):
             state['runner'].stop()
 
 
-class Checkpointer(ImprovementHandlerMixin):
-    """A handler for checkpointing.
+class Checkpointer(ImprovementCallbackMixin):
+    """A callback for checkpointing.
 
     Checkpointing here means saving some objects (e.g., models) periodically during a run.
 
@@ -127,7 +127,7 @@ class Checkpointer(ImprovementHandlerMixin):
         >>> from pathlib import Path
         >>> from pprint import pprint
         >>> from rnnr import Event, Runner
-        >>> from rnnr.handlers import Checkpointer
+        >>> from rnnr.callbacks import Checkpointer
         >>>
         >>> batches = range(3)
         >>> batch_fn = lambda _: None
@@ -152,8 +152,8 @@ class Checkpointer(ImprovementHandlerMixin):
         checkpoint_key: Get the checkpoint from ``state[checkpoint_key]``. A checkpoint
             is a mapping whose keys are filenames and the values are the objects to checkpoint.
             The filenames in this dictionary's keys are prepended with the number of times
-            this handler is called to get the actual saved files' names. This allows the
-            actual filenames contain the e.g. epoch number if this handler is invoked at the
+            this callback is called to get the actual saved files' names. This allows the
+            actual filenames contain the e.g. epoch number if this callback is invoked at the
             end of each epoch.
         max_saved: Maximum number of checkpoints saved.
         save_fn: Function to invoke to save the checkpoints. If given, this must be a callable
@@ -161,7 +161,7 @@ class Checkpointer(ImprovementHandlerMixin):
             is to save the object using `pickle`.
         value_key: Get some value from ``state[value_key]``. Checkpoints are saved only
             when this value improves over the best value observed so far. The default
-            of ``None`` means checkpoints are always saved whenever this handler is called.
+            of ``None`` means checkpoints are always saved whenever this callback is called.
         mode: Whether to consider lower (``min``) or higher (``max``) value as improvement.
         eps: Improvement is considered only when the value improves by at least this amount.
             Only used if ``value_key`` is given and it is an instance of `float`.

--- a/rnnr/handlers.py
+++ b/rnnr/handlers.py
@@ -76,7 +76,7 @@ class EarlyStopper(ImprovementHandlerMixin):
         ...     eval_state = evaluator.run(eval_fn, valid_losses)
         ...     state['loss'] = eval_state['mean']
         ...
-        >>> trainer.append_handler(Event.EPOCH_FINISHED, EarlyStopper(patience=2))
+        >>> trainer.on(Event.EPOCH_FINISHED, EarlyStopper(patience=2))
         >>> _ = trainer.run(batch_fn, batches, max_epoch=7)
         Epoch 1 started
         Epoch 2 started
@@ -137,7 +137,7 @@ class Checkpointer(ImprovementHandlerMixin):
         ... def store_checkpoint(state):
         ...     state['checkpoint'] = {'model.pkl': 'MODEL', 'optimizer.pkl': 'OPTIMIZER'}
         ...
-        >>> runner.append_handler(Event.EPOCH_FINISHED, Checkpointer(tmp_dir, max_saved=3))
+        >>> runner.on(Event.EPOCH_FINISHED, Checkpointer(tmp_dir, max_saved=3))
         >>> _ = runner.run(batch_fn, batches, max_epoch=7)
         >>> pprint(sorted(list(tmp_dir.glob('*.pkl'))))
         [PosixPath('/tmp/5_model.pkl'),

--- a/rnnr/runner.py
+++ b/rnnr/runner.py
@@ -70,7 +70,7 @@ class Runner:
             event: Event,
             callback: Optional[Callback] = None,
     ) -> Optional[Callable[[Callback], Callback]]:
-        """Append a callback to listen to an event.
+        """Add a callback to listen to an event.
 
         When ``callback`` is ``None``, this method returns a decorator which accepts
         a callback for the event.

--- a/rnnr/runner.py
+++ b/rnnr/runner.py
@@ -14,7 +14,7 @@
 
 from collections import defaultdict
 from datetime import timedelta
-from typing import Any, Callable, Dict, Iterable, List
+from typing import Any, Callable, Dict, Iterable, List, Optional
 import time
 import logging
 
@@ -73,7 +73,15 @@ class Runner:
             elapsed = timedelta(seconds=time.time() - self._epoch_start_time)
             logger.info('Epoch %d/%d done in %s', state['epoch'], state['max_epoch'], elapsed)
 
-    def on(self, event: Event) -> Callable[[Handler], Handler]:
+    def on(
+            self,
+            event: Event,
+            handler: Optional[Handler] = None,
+    ) -> Optional[Callable[[Handler], Handler]]:
+        if handler is not None:
+            self._handlers[event].append(handler)
+            return None
+
         def decorator(handler: Handler) -> Handler:
             self.append_handler(event, handler)
             return handler

--- a/rnnr/runner.py
+++ b/rnnr/runner.py
@@ -43,7 +43,7 @@ class Runner:
       handlers of `Event.BATCH_STARTED` and `Event.BATCH_FINISHED`, as well as ``batch_fn``
       passed to `~Runner.run`.
 
-    Note that handlers for an event are called in the order they are appended.
+    Note that handlers for an event are called in the order they are passed to `~Runner.on`.
     """
 
     def __init__(self) -> None:
@@ -69,6 +69,18 @@ class Runner:
             event: Event,
             handler: Optional[Handler] = None,
     ) -> Optional[Callable[[Handler], Handler]]:
+        """Append a handler to listen to an event.
+
+        When ``handler`` is ``None``, this method returns a decorator which accepts
+        a handler and append it for the event.
+
+        Args:
+            event: Event to listen.
+            handler: Handler for the event.
+
+        Returns:
+            A decorator which accepts a handler, if ``handler`` is ``None``.
+        """
         if handler is not None:
             self._handlers[event].append(handler)
             return None

--- a/rnnr/runner.py
+++ b/rnnr/runner.py
@@ -30,7 +30,7 @@ class Runner:
     A runner provides a thin abstraction of iterating over batches for several epochs,
     which is typically done in neural network training. To customize the behavior during
     a run, a runner provides a way to listen to events emitted during such run.
-    To listen to an event, call `Runner.append_handler` and provide the event handler.
+    To listen to an event, call `Runner.on` and provide the event handler.
     A handler is a callable that accepts a `dict` and returns nothing. The `dict` is
     the state of the run. By default, the state contains:
 
@@ -51,17 +51,8 @@ class Runner:
         self._running = False
         self._epoch_start_time = 0.
 
-        self.append_handler(Event.EPOCH_STARTED, self._print_start_epoch)
-        self.append_handler(Event.EPOCH_FINISHED, self._print_finish_epoch)
-
-    def append_handler(self, event: Event, handler: Handler) -> None:
-        """Append a handler for the given event.
-
-        Args:
-            event: Event to handle.
-            handler: Handler for the event.
-        """
-        self._handlers[event].append(handler)
+        self.on(Event.EPOCH_STARTED, self._print_start_epoch)
+        self.on(Event.EPOCH_FINISHED, self._print_finish_epoch)
 
     def _print_start_epoch(self, state: dict) -> None:
         if state['max_epoch'] > 1:
@@ -83,7 +74,7 @@ class Runner:
             return None
 
         def decorator(handler: Handler) -> Handler:
-            self.append_handler(event, handler)
+            self._handlers[event].append(handler)
             return handler
 
         return decorator

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -3,7 +3,7 @@ import pickle
 
 import pytest
 
-from rnnr.handlers import Checkpointer
+from rnnr.callbacks import Checkpointer
 
 
 def test_ok(tmp_path):

--- a/tests/test_early_stopper.py
+++ b/tests/test_early_stopper.py
@@ -2,7 +2,7 @@ from unittest.mock import call, patch
 
 import pytest
 
-from rnnr.handlers import EarlyStopper
+from rnnr.callbacks import EarlyStopper
 
 
 def test_ok(runner):

--- a/tests/test_mean_reducer.py
+++ b/tests/test_mean_reducer.py
@@ -29,13 +29,13 @@ def test_more_than_one_epoch(runner):
         ix = (state['epoch'] - 1) * len(batches) + state['batch']
         state['output'] = values[ix]
 
-    def efhandler(state):
+    def efcallback(state):
         assert state[r.name] == pytest.approx(
             stat.mean(values[(state['epoch'] - 1) * len(batches) + b] for b in batches))
 
     r = MeanReducer()
     r.attach_on(runner)
-    runner.on(Event.EPOCH_FINISHED, efhandler)
+    runner.on(Event.EPOCH_FINISHED, efcallback)
     runner.run(batch_fn, batches, max_epoch=2)
 
 

--- a/tests/test_mean_reducer.py
+++ b/tests/test_mean_reducer.py
@@ -35,7 +35,7 @@ def test_more_than_one_epoch(runner):
 
     r = MeanReducer()
     r.attach_on(runner)
-    runner.append_handler(Event.EPOCH_FINISHED, efhandler)
+    runner.on(Event.EPOCH_FINISHED, efhandler)
     runner.run(batch_fn, batches, max_epoch=2)
 
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -139,41 +139,41 @@ class TestOn:
 
 class TestStop:
     def test_on_batch_started(self, runner):
-        mock_eshandler = Mock()
-        mock_bfhandler = Mock()
-        mock_efhandler = Mock()
+        mock_escallback = Mock()
+        mock_bfcallback = Mock()
+        mock_efcallback = Mock()
         batches = range(10)
 
-        def bshandler(state):
+        def bscallback(state):
             if state['batch'] == 3:
                 runner.stop()
 
-        runner.on(Event.EPOCH_STARTED, mock_eshandler)
-        runner.on(Event.BATCH_STARTED, bshandler)
-        runner.on(Event.BATCH_FINISHED, mock_bfhandler)
-        runner.on(Event.EPOCH_FINISHED, mock_efhandler)
+        runner.on(Event.EPOCH_STARTED, mock_escallback)
+        runner.on(Event.BATCH_STARTED, bscallback)
+        runner.on(Event.BATCH_FINISHED, mock_bfcallback)
+        runner.on(Event.EPOCH_FINISHED, mock_efcallback)
         runner.run(Mock(), batches, max_epoch=2)
 
-        assert mock_eshandler.call_count == 1
-        assert mock_bfhandler.call_count == 4
-        assert mock_efhandler.call_count == 1
+        assert mock_escallback.call_count == 1
+        assert mock_bfcallback.call_count == 4
+        assert mock_efcallback.call_count == 1
 
     def test_on_epoch_started(self, runner):
-        mock_bshandler = Mock()
-        mock_bfhandler = Mock()
-        mock_efhandler = Mock()
+        mock_bscallback = Mock()
+        mock_bfcallback = Mock()
+        mock_efcallback = Mock()
         batches = range(10)
 
-        def eshandler(state):
+        def escallback(state):
             if state['epoch'] == 1:
                 runner.stop()
 
-        runner.on(Event.EPOCH_STARTED, eshandler)
-        runner.on(Event.BATCH_STARTED, mock_bshandler)
-        runner.on(Event.BATCH_FINISHED, mock_bfhandler)
-        runner.on(Event.EPOCH_FINISHED, mock_efhandler)
+        runner.on(Event.EPOCH_STARTED, escallback)
+        runner.on(Event.BATCH_STARTED, mock_bscallback)
+        runner.on(Event.BATCH_FINISHED, mock_bfcallback)
+        runner.on(Event.EPOCH_FINISHED, mock_efcallback)
         runner.run(Mock(), batches, max_epoch=7)
 
-        assert mock_bshandler.call_count == 0
-        assert mock_bfhandler.call_count == 0
-        assert mock_efhandler.call_count == 1
+        assert mock_bscallback.call_count == 0
+        assert mock_bfcallback.call_count == 0
+        assert mock_efcallback.call_count == 1

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -136,6 +136,14 @@ class TestOn:
         runner.run(Mock(), range(5), max_epoch=max_epoch)
         assert n_calls == max_epoch
 
+    def test_multiple_callbacks(self, runner):
+        mock_escb1, mock_escb2, max_epoch = Mock(), Mock(), 10
+        runner.on(Event.EPOCH_STARTED, [mock_escb1, mock_escb2])
+        runner.run(Mock(), range(5), max_epoch=max_epoch)
+
+        assert mock_escb1.call_count == max_epoch
+        assert mock_escb2.call_count == max_epoch
+
 
 class TestStop:
     def test_on_batch_started(self, runner):

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -148,10 +148,10 @@ class TestStop:
             if state['batch'] == 3:
                 runner.stop()
 
-        runner.append_handler(Event.EPOCH_STARTED, mock_eshandler)
-        runner.append_handler(Event.BATCH_STARTED, bshandler)
-        runner.append_handler(Event.BATCH_FINISHED, mock_bfhandler)
-        runner.append_handler(Event.EPOCH_FINISHED, mock_efhandler)
+        runner.on(Event.EPOCH_STARTED, mock_eshandler)
+        runner.on(Event.BATCH_STARTED, bshandler)
+        runner.on(Event.BATCH_FINISHED, mock_bfhandler)
+        runner.on(Event.EPOCH_FINISHED, mock_efhandler)
         runner.run(Mock(), batches, max_epoch=2)
 
         assert mock_eshandler.call_count == 1
@@ -168,10 +168,10 @@ class TestStop:
             if state['epoch'] == 1:
                 runner.stop()
 
-        runner.append_handler(Event.EPOCH_STARTED, eshandler)
-        runner.append_handler(Event.BATCH_STARTED, mock_bshandler)
-        runner.append_handler(Event.BATCH_FINISHED, mock_bfhandler)
-        runner.append_handler(Event.EPOCH_FINISHED, mock_efhandler)
+        runner.on(Event.EPOCH_STARTED, eshandler)
+        runner.on(Event.BATCH_STARTED, mock_bshandler)
+        runner.on(Event.BATCH_FINISHED, mock_bfhandler)
+        runner.on(Event.EPOCH_FINISHED, mock_efhandler)
         runner.run(Mock(), batches, max_epoch=7)
 
         assert mock_bshandler.call_count == 0


### PR DESCRIPTION
This PR combined `Runner.append_handler` with `Runner.on`, allowing the latter to accept an optional 2nd argument. This change makes the API more DSL-like with `runner.on(event, do_stuff)` instead of `runner.append_handler(event, do_stuff)` like before. Also, "handlers" is now renamed to "callbacks" because it's more appropriate now we don't have `append_handler` any more.