### PR TITLE
Use better state keys and rename some args

### DIFF
--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -91,6 +91,7 @@ class ProgressBar(Attachment):
 
     def __init__(
             self,
+            *,
             n_items: str = 'n_items',
             stats: Optional[str] = None,
             tqdm_cls: Optional[Type[tqdm]] = None,
@@ -155,6 +156,7 @@ class LambdaReducer(Attachment):
             self,
             name: str,
             reduce_fn: Callable[[Any, Any], Any],
+            *,
             value: str = 'output',
     ) -> None:
         self.name = name
@@ -211,6 +213,7 @@ class MeanReducer(LambdaReducer):
     def __init__(
             self,
             name: str = 'mean',
+            *,
             value: str = 'output',
             size: str = 'size',
     ) -> None:

--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -78,10 +78,9 @@ class ProgressBar(Attachment):
         >>> runner.run(range(10), max_epoch=10)
 
     Args:
-        size_key: Get the size of a batch from ``state[size_key]`` to update the
-            progress bar with. If not given, the default is to always set 1 as the size of
-            a batch.
-        stats_key: Get the batch statistics from ``state[stats_key]`` and display it along
+        n_items: Get the number of items in a batch from ``state[n_items]`` to update the
+            progress bar with. If not given, the default is to always set it to 1.
+        stats: Get the batch statistics from ``state[stats]`` and display it along
             with the progress bar. The statistics dictionary has the names of the statistics
             as keys and the statistics as values.
         **kwargs: Keyword arguments to be passed to `tqdm`_ class.
@@ -92,8 +91,8 @@ class ProgressBar(Attachment):
 
     def __init__(
             self,
-            size_key: str = 'n_items',
-            stats_key: Optional[str] = None,
+            n_items: str = 'n_items',
+            stats: Optional[str] = None,
             tqdm_cls: Optional[Type[tqdm]] = None,
             **kwargs,
     ) -> None:
@@ -101,8 +100,8 @@ class ProgressBar(Attachment):
             tqdm_cls = tqdm
 
         self._tqdm_cls = tqdm_cls
-        self._size_key = size_key
-        self._stats_key = stats_key
+        self._n_items = n_items
+        self._stats = stats
         self._kwargs = kwargs
 
         self._pbar: tqdm
@@ -116,9 +115,9 @@ class ProgressBar(Attachment):
         self._pbar = self._tqdm_cls(state['batches'], **self._kwargs)
 
     def _update(self, state: dict) -> None:
-        if self._stats_key is not None:
-            self._pbar.set_postfix(**state[self._stats_key])
-        self._pbar.update(state.get(self._size_key, 1))
+        if self._stats is not None:
+            self._pbar.set_postfix(**state[self._stats])
+        self._pbar.update(state.get(self._n_items, 1))
 
     def _close(self, state: dict) -> None:
         self._pbar.close()

--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -192,7 +192,7 @@ class MeanReducer(LambdaReducer):
         >>> from rnnr import Event, Runner
         >>> from rnnr.attachments import MeanReducer
         >>> runner = Runner()
-        >>> MeanReducer().attach_on(runner)
+        >>> MeanReducer('mean').attach_on(runner)
         >>> @runner.on(Event.BATCH)
         ... def on_batch(state):
         ...     state['output'] = state['batch']
@@ -212,7 +212,7 @@ class MeanReducer(LambdaReducer):
 
     def __init__(
             self,
-            name: str = 'mean',
+            name: str,
             *,
             value: str = 'output',
             size: str = 'size',

--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -148,18 +148,18 @@ class LambdaReducer(Attachment):
             state dict to store the reduction result.
         reduce_fn: Reduction function. It should accept two batch values and
             return their reduction result.
-        value_key: Get the value of a batch from ``state[value_key]``.
+        value: Get the value of a batch from ``state[value]``.
     """
 
     def __init__(
             self,
             name: str,
             reduce_fn: Callable[[Any, Any], Any],
-            value_key: str = 'output',
+            value: str = 'output',
     ) -> None:
         self.name = name
         self._reduce_fn = reduce_fn
-        self._value_key = value_key
+        self._value = value
 
     def attach_on(self, runner: Runner) -> None:
         runner.on(Event._REDUCER_RESET, self._reset)
@@ -171,9 +171,9 @@ class LambdaReducer(Attachment):
 
     def _update(self, state: dict) -> None:
         if self._result is None:
-            self._result = state[self._value_key]
+            self._result = state[self._value]
         else:
-            self._result = self._reduce_fn(self._result, state[self._value_key])
+            self._result = self._reduce_fn(self._result, state[self._value])
 
     def _compute(self, state: dict) -> None:
         state[self.name] = self._result
@@ -214,7 +214,7 @@ class MeanReducer(LambdaReducer):
             value_key: str = 'output',
             size_key: str = 'size',
     ) -> None:
-        super().__init__(name, lambda x, y: x + y, value_key=value_key)
+        super().__init__(name, lambda x, y: x + y, value=value_key)
         self._size_key = size_key
         self._size = 0
 

--- a/rnnr/attachments.py
+++ b/rnnr/attachments.py
@@ -202,30 +202,30 @@ class MeanReducer(LambdaReducer):
     Args:
         name: Name of this attachment to be used as the key in the runner's state
             dict to store the mean value.
-        value_key: Get the value of a batch from ``state[value_key]``.
-        size_key: Get the size of a batch from ``state[size_key]``. If
-            the state has no such key, the size defaults to 1. The sum of all these
-            batch sizes is the divisor when computing the mean.
+        value: Get the value of a batch from ``state[value]``.
+        size: Get the size of a batch from ``state[size]``. If the state has no such key,
+            the size defaults to 1. The sum of all these batch sizes is the divisor when
+            computing the mean.
     """
 
     def __init__(
             self,
             name: str = 'mean',
-            value_key: str = 'output',
-            size_key: str = 'size',
+            value: str = 'output',
+            size: str = 'size',
     ) -> None:
-        super().__init__(name, lambda x, y: x + y, value=value_key)
-        self._size_key = size_key
-        self._size = 0
+        super().__init__(name, lambda x, y: x + y, value=value)
+        self._size = size
+        self._total_size = 0
 
     def _reset(self, state: dict) -> None:
         super()._reset(state)
-        self._size = 0
+        self._total_size = 0
 
     def _update(self, state: dict) -> None:
         super()._update(state)
-        self._size += state.get(self._size_key, 1)
+        self._total_size += state.get(self._size, 1)
 
     def _compute(self, state: dict) -> None:
         super()._compute(state)
-        state[self.name] /= self._size
+        state[self.name] /= self._total_size

--- a/rnnr/callbacks.py
+++ b/rnnr/callbacks.py
@@ -69,7 +69,7 @@ def stop_epoch_timer(*, key: str = '_epoch_start_time'):  # pragma: no cover
     return callback
 
 
-def maybe_stop_early(*, check: str = 'better', patience: int = 5, counter: str = 'counter'):
+def maybe_stop_early(*, check: str = 'better', patience: int = 5, counter: str = '_counter'):
     """A callback factory for early stopping.
 
     The returned calback keeps a counter in ``state[counter]`` for the number of times

--- a/rnnr/callbacks.py
+++ b/rnnr/callbacks.py
@@ -140,7 +140,7 @@ def checkpoint(
         using: Optional[Callable[[Any, Path], None]] = None,
         ext: str = 'pkl',
         prefix_fmt: str = '{epoch}_',
-        queue_fmt: str = 'saved_{what}',
+        queue_fmt: str = '_saved_{what}',
 ):
     """A callback factory for checkpointing.
 

--- a/rnnr/callbacks.py
+++ b/rnnr/callbacks.py
@@ -21,7 +21,7 @@ import pickle
 import time
 
 
-def start_epoch_timer(*, key: str = 'epoch_start_time'):  # pragma: no cover
+def start_epoch_timer(*, key: str = '_epoch_start_time'):  # pragma: no cover
     """A callback factory to record the start time of an epoch.
 
     Together with `stop_epoch_timer`, this callback provides an alternative to
@@ -45,7 +45,7 @@ def start_epoch_timer(*, key: str = 'epoch_start_time'):  # pragma: no cover
     return callback
 
 
-def stop_epoch_timer(*, key: str = 'epoch_start_time'):  # pragma: no cover
+def stop_epoch_timer(*, key: str = '_epoch_start_time'):  # pragma: no cover
     """A callback factory to report the elapsed time of an epoch.
 
     Together with `start_epoch_timer`, this callback provides an alternative to

--- a/rnnr/runner.py
+++ b/rnnr/runner.py
@@ -15,7 +15,7 @@
 from collections import defaultdict
 from typing import Any, Callable, Dict, Iterable, List
 
-from rnnr.event import Event
+from .event import Event
 
 Callback = Callable[[dict], None]
 

--- a/tests/test_lambda_reducer.py
+++ b/tests/test_lambda_reducer.py
@@ -20,7 +20,7 @@ def test_ok(runner):
     assert runner.state['product'] == reduce(lambda x, y: x * y, outputs)
 
 
-def test_value_key(runner):
+def test_value(runner):
     outputs = [4, 2, 1, 5, 6]
     batches = range(len(outputs))
 
@@ -28,7 +28,7 @@ def test_value_key(runner):
     def on_batch(state):
         state['value'] = outputs[state['batch']]
 
-    r = LambdaReducer('product', lambda x, y: x * y, value_key='value')
+    r = LambdaReducer('product', lambda x, y: x * y, value='value')
     r.attach_on(runner)
     runner.run(batches)
 

--- a/tests/test_mean_reducer.py
+++ b/tests/test_mean_reducer.py
@@ -14,7 +14,7 @@ def test_ok(runner):
     def on_batch(state):
         state['output'] = values[state['batch']]
 
-    r = MeanReducer()
+    r = MeanReducer('mean')
     r.attach_on(runner)
     runner.run(batches)
 
@@ -35,15 +35,10 @@ def test_more_than_one_epoch(runner):
         assert state[r.name] == pytest.approx(
             stat.mean(values[(state['epoch'] - 1) * len(batches) + b] for b in batches))
 
-    r = MeanReducer()
+    r = MeanReducer('mean')
     r.attach_on(runner)
     runner.on(Event.EPOCH_FINISHED, efcallback)
     runner.run(batches, max_epoch=2)
-
-
-def test_custom_name(runner):
-    r = MeanReducer(name='avg')
-    assert r.name == 'avg'
 
 
 def test_value(runner):
@@ -53,7 +48,7 @@ def test_value(runner):
     def on_batch(state):
         state['value'] = state['batch']**3
 
-    r = MeanReducer(value='value')
+    r = MeanReducer('mean', value='value')
     r.attach_on(runner)
     runner.run(batches)
 
@@ -69,7 +64,7 @@ def test_size(runner):
         state['output'] = state['batch']
         state['foo'] = sizes[state['batch']]
 
-    r = MeanReducer(size='foo')
+    r = MeanReducer('mean', size='foo')
     r.attach_on(runner)
     runner.run(batches)
 

--- a/tests/test_mean_reducer.py
+++ b/tests/test_mean_reducer.py
@@ -46,21 +46,21 @@ def test_custom_name(runner):
     assert r.name == 'avg'
 
 
-def test_value_key(runner):
+def test_value(runner):
     batches = range(10)
 
     @runner.on(Event.BATCH)
     def on_batch(state):
         state['value'] = state['batch']**3
 
-    r = MeanReducer(value_key='value')
+    r = MeanReducer(value='value')
     r.attach_on(runner)
     runner.run(batches)
 
     assert runner.state[r.name] == pytest.approx(stat.mean(b**3 for b in batches))
 
 
-def test_size_key(runner):
+def test_size(runner):
     batches = range(5)
     sizes = [3, 4, 9, 10, 2]
 
@@ -69,7 +69,7 @@ def test_size_key(runner):
         state['output'] = state['batch']
         state['foo'] = sizes[state['batch']]
 
-    r = MeanReducer(size_key='foo')
+    r = MeanReducer(size='foo')
     r.attach_on(runner)
     runner.run(batches)
 

--- a/tests/test_pbar.py
+++ b/tests/test_pbar.py
@@ -19,7 +19,7 @@ def test_ok(runner):
     mock_tqdm_cls.return_value.close.assert_called_once_with()
 
 
-def test_default_size_key(runner):
+def test_default_n_items(runner):
     batches = [list('foo'), list('quux')]
     mock_tqdm_cls = MagicMock(spec=tqdm)
 
@@ -34,7 +34,7 @@ def test_default_size_key(runner):
     assert mock_tqdm_cls.return_value.update.mock_calls == [call(len(b)) for b in batches]
 
 
-def test_size_key(runner):
+def test_n_items(runner):
     batches = [list('foo'), list('quux')]
     mock_tqdm_cls = MagicMock(spec=tqdm)
 
@@ -42,14 +42,14 @@ def test_size_key(runner):
     def on_batch(state):
         state['foo'] = len(state['batch'])
 
-    pbar = ProgressBar(tqdm_cls=mock_tqdm_cls, size_key='foo')
+    pbar = ProgressBar(tqdm_cls=mock_tqdm_cls, n_items='foo')
     pbar.attach_on(runner)
     runner.run(batches)
 
     assert mock_tqdm_cls.return_value.update.mock_calls == [call(len(b)) for b in batches]
 
 
-def test_stats_key(runner):
+def test_stats(runner):
     batches = range(10)
     mock_tqdm_cls = MagicMock(spec=tqdm)
 
@@ -57,7 +57,7 @@ def test_stats_key(runner):
     def on_batch(state):
         state['stats'] = {'loss': state['batch']**2}
 
-    pbar = ProgressBar(tqdm_cls=mock_tqdm_cls, stats_key='stats')
+    pbar = ProgressBar(tqdm_cls=mock_tqdm_cls, stats='stats')
     pbar.attach_on(runner)
     runner.run(batches)
 


### PR DESCRIPTION
- Prefix state keys to write with an underscore to avoid clash with user-defined ones.
- Simplify some state keys args by dropping the `_key` suffix.
- Make some args keyword-only.